### PR TITLE
Add sidebar with profile and tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,15 +9,19 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header>
-    <h1>Kian Thomasbeer</h1>
-    <p>Data Science | Web Projects | ML Nerd</p>
-    <div class="profile-container">
-      <img src="profile.jpg" alt="Profile Picture" />
-    </div>
-  </header>
-  <main>
-    <details open>
+  <div class="container">
+    <aside class="sidebar">
+      <a href="profile.jpg" target="_blank">
+        <img src="profile.jpg" alt="Profile Picture" class="profile-img" />
+      </a>
+      <a href="#about" class="tagline">Data Science | Web Projects | ML Nerd</a>
+    </aside>
+    <div class="content">
+      <header>
+        <h1>Kian Thomasbeer</h1>
+      </header>
+      <main>
+    <details id="about" open>
       <summary>👋 About Me</summary>
       <p>
         Hi! I'm Kian Thomasbeer, a statistics major passionate about uncovering insights through data and building projects that combine creativity with machine learning.
@@ -51,6 +55,8 @@
   <footer>
     &copy; <span id="year">2025</span> Kian Thomasbeer. All rights reserved.
   </footer>
+      </div>
+    </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,37 +1,59 @@
-    body {
-      margin: 0;
-      font-family: 'Inter', sans-serif;
-      background-color: #f5f5f5;
-      color: #333;
-    }
-    header {
+  body {
+    margin: 0;
+    font-family: 'Inter', sans-serif;
+    background-color: #f5f5f5;
+    color: #333;
+  }
+
+  .container {
+    display: flex;
+    min-height: 100vh;
+  }
+
+  .sidebar {
+    width: 220px;
+    background-color: #1a1a1a;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 1rem;
+  }
+
+  .profile-img {
+    width: 160px;
+    height: 160px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 4px solid #fff;
+    transition: transform 0.2s;
+  }
+
+  .profile-img:hover {
+    transform: scale(1.05);
+  }
+
+  .tagline {
+    margin-top: 1rem;
+    font-weight: 600;
+    color: #fff;
+    text-align: center;
+  }
+
+  .content {
+    flex: 1;
+  }
+header {
       background-color: #1a1a1a;
       color: white;
       padding: 2rem 1rem;
       text-align: center;
     }
-    header h1 {
+header h1 {
       margin: 0;
       font-size: 2.5rem;
     }
-    header p {
-      margin: 0.5rem 0 0;
-      font-size: 1.2rem;
-    }
-    .profile-container {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      margin-top: 1rem;
-    }
-    .profile-container img {
-      width: 150px;
-      height: 150px;
-      border-radius: 50%;
-      object-fit: cover;
-      border: 4px solid #1a1a1a;
-    }
-    main {
+main {
       max-width: 800px;
       margin: 2rem auto;
       padding: 0 1rem;
@@ -80,18 +102,23 @@
     }
 
     /* Responsive Styling */
-    @media (max-width: 600px) {
-      header h1 {
-        font-size: 2rem;
+      @media (max-width: 600px) {
+        .container {
+          flex-direction: column;
+        }
+        .sidebar {
+          width: 100%;
+          flex-direction: row;
+          justify-content: center;
+        }
+        .profile-img {
+          width: 120px;
+          height: 120px;
+        }
+        header h1 {
+          font-size: 2rem;
+        }
+        main {
+          padding: 0 0.8rem;
+        }
       }
-      header p {
-        font-size: 1rem;
-      }
-      .profile-container img {
-        width: 120px;
-        height: 120px;
-      }
-      main {
-        padding: 0 0.8rem;
-      }
-    }


### PR DESCRIPTION
## Summary
- create fixed sidebar with profile picture
- move tagline to sidebar and link to About section
- adjust layout and responsive design

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847a4de8e20833291a8ea8da6811a07