### PR TITLE
Add sidebar with profile and 6 navigation tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,52 +5,61 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kian Thomasbeer</title>
   <link rel="icon" type="image/png" href="favicon.png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&amp;display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header>
-    <h1>Kian Thomasbeer</h1>
-    <p>Data Science | Web Projects | ML Nerd</p>
-    <div class="profile-container">
-      <img src="profile.jpg" alt="Profile Picture" />
-    </div>
-  </header>
-  <main>
-    <details open>
-      <summary>👋 About Me</summary>
-      <p>
-        Hi! I'm Kian Thomasbeer, a statistics major passionate about uncovering insights through data and building projects that combine creativity with machine learning.
-        I’m currently exploring the intersection of ML, food, and games through personal projects like a personalized album recommender and an MTG meta predictor.
-      </p>
-      <p>
-        Outside of data science, I run a recipe blog that explores global cuisine and share weekly dishes on
-        <a href="https://www.instagram.com/worldplatechronicles/" target="_blank">Instagram</a>. I also enjoy playing ultimate frisbee and tinkering with web tools.
-      </p>
-      <p>
-        I’m always looking for interesting problems to solve and people to build with — feel free to reach out or check out my recent work below!
-      </p>
-    </details>
-    <details>
-      <summary>📁 Projects</summary>
-      <ul>
-        <li><strong>Meta Morph</strong>: A model that predicts MTG meta shifts using NLP and graph theory.</li>
-        <li><strong>Global Plate Chronicles</strong>: A recipe blog exploring world cuisine, updated weekly.</li>
-        <li><strong>Pass Predictor</strong>: A sports analytics tool using image data to classify completed passes.</li>
-      </ul>
-    </details>
-    <details>
-      <summary>📬 Contact</summary>
-      <p>
-        📧 <a href="mailto:kayennepeppaa@gmail.com">kayennepeppaa@gmail.com</a><br />
-        💻 <a href="https://github.com/MrHim0thy" target="_blank">GitHub Profile</a><br />
-        📸 <a href="https://www.instagram.com/kianthomasbeer/" target="_blank">Instagram</a>
-      </p>
-    </details>
-  </main>
-  <footer>
-    &copy; <span id="year">2025</span> Kian Thomasbeer. All rights reserved.
-  </footer>
+  <div class="sidebar">
+    <img src="profile.jpg" alt="Profile Picture" class="profile-img" />
+    <nav class="nav-links">
+      <a href="#home">Home</a>
+      <a href="#about">About</a>
+      <a href="#projects">Projects</a>
+      <a href="#blog">Blog</a>
+      <a href="#recipes">Recipes</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </div>
+  <div class="content">
+    <header id="home">
+      <h1>Kian Thomasbeer</h1>
+    </header>
+    <main>
+      <details id="about" open>
+        <summary>👋 About Me</summary>
+        <p>Hi! I'm Kian Thomasbeer, a statistics major passionate about uncovering insights through data and building projects that combine creativity with machine learning. I’m currently exploring the intersection of ML, food, and games through personal projects like a personalized album recommender and an MTG meta predictor.</p>
+        <p>Outside of data science, I run a recipe blog that explores global cuisine and share weekly dishes on <a href="https://www.instagram.com/worldplatechronicles/" target="_blank">Instagram</a>. I also enjoy playing ultimate frisbee and tinkering with web tools.</p>
+        <p>I’m always looking for interesting problems to solve and people to build with — feel free to reach out or check out my recent work below!</p>
+      </details>
+      <details id="projects">
+        <summary>📁 Projects</summary>
+        <ul>
+          <li><strong>Meta Morph</strong>: A model that predicts MTG meta shifts using NLP and graph theory.</li>
+          <li><strong>Global Plate Chronicles</strong>: A recipe blog exploring world cuisine, updated weekly.</li>
+          <li><strong>Pass Predictor</strong>: A sports analytics tool using image data to classify completed passes.</li>
+        </ul>
+      </details>
+      <details id="blog">
+        <summary>📝 Blog</summary>
+        <p>Coming soon!</p>
+      </details>
+      <details id="recipes">
+        <summary>🍲 Recipes</summary>
+        <p>Check out <a href="https://www.instagram.com/worldplatechronicles/" target="_blank">Instagram</a> for weekly dishes.</p>
+      </details>
+      <details id="contact">
+        <summary>📬 Contact</summary>
+        <p>
+          📧 <a href="mailto:kayennepeppaa@gmail.com">kayennepeppaa@gmail.com</a><br />
+          💻 <a href="https://github.com/MrHim0thy" target="_blank">GitHub Profile</a><br />
+          📸 <a href="https://www.instagram.com/kianthomasbeer/" target="_blank">Instagram</a>
+        </p>
+      </details>
+    </main>
+    <footer>
+      &copy; <span id="year">2025</span> Kian Thomasbeer. All rights reserved.
+    </footer>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,37 +1,75 @@
-    body {
-      margin: 0;
-      font-family: 'Inter', sans-serif;
-      background-color: #f5f5f5;
-      color: #333;
-    }
-    header {
+  body {
+    margin: 0;
+    font-family: 'Inter', sans-serif;
+    background-color: #f5f5f5;
+    color: #333;
+  }
+
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 220px;
+    background-color: #1a1a1a;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 1rem;
+    overflow-y: auto;
+  }
+
+  .profile-img {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 4px solid #fff;
+    transition: transform 0.2s;
+  }
+
+  .profile-img:hover {
+    transform: scale(1.05);
+  }
+
+  .nav-links {
+    margin-top: 2rem;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .nav-links a {
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    text-align: center;
+  }
+
+  .nav-links a:hover {
+    background-color: #333;
+    text-decoration: none;
+  }
+
+
+  .content {
+    flex: 1;
+    margin-left: 220px;
+  }
+header {
       background-color: #1a1a1a;
       color: white;
       padding: 2rem 1rem;
       text-align: center;
     }
-    header h1 {
+header h1 {
       margin: 0;
       font-size: 2.5rem;
     }
-    header p {
-      margin: 0.5rem 0 0;
-      font-size: 1.2rem;
-    }
-    .profile-container {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      margin-top: 1rem;
-    }
-    .profile-container img {
-      width: 150px;
-      height: 150px;
-      border-radius: 50%;
-      object-fit: cover;
-      border: 4px solid #1a1a1a;
-    }
-    main {
+main {
       max-width: 800px;
       margin: 2rem auto;
       padding: 0 1rem;
@@ -79,19 +117,34 @@
       text-decoration: underline;
     }
 
-    /* Responsive Styling */
-    @media (max-width: 600px) {
-      header h1 {
-        font-size: 2rem;
-      }
-      header p {
-        font-size: 1rem;
-      }
-      .profile-container img {
-        width: 120px;
-        height: 120px;
-      }
-      main {
-        padding: 0 0.8rem;
-      }
+  /* Responsive Styling */
+  @media (max-width: 600px) {
+    .sidebar {
+      position: relative;
+      width: 100%;
+      flex-direction: row;
+      align-items: center;
+      padding: 1rem;
+      height: auto;
     }
+    .nav-links {
+      flex-direction: row;
+      justify-content: space-around;
+      width: auto;
+      margin-top: 0;
+    }
+    .profile-img {
+      width: 80px;
+      height: 80px;
+      margin-right: 1rem;
+    }
+    .content {
+      margin-left: 0;
+    }
+    header h1 {
+      font-size: 2rem;
+    }
+    main {
+      padding: 0 0.8rem;
+    }
+  }


### PR DESCRIPTION
## Summary
- redesign sidebar layout and make it fixed on the left
- add navigation links for Home, About, Projects, Blog, Recipes and Contact
- shrink profile image and modernize sidebar styles
- adjust responsive layout for small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847a4de8e20833291a8ea8da6811a07