### PR TITLE
Add contact icons to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,13 +17,17 @@
       <a href="#projects">Projects</a>
       <a href="#blog">Blog</a>
       <a href="#recipes">Recipes</a>
-      <a href="#contact">Contact</a>
       </nav>
       <a href="resume_6.1.pdf" target="_blank" class="resume-btn">Resume</a>
     </div>
   <div class="content">
     <header id="home">
       <h1>Kian Thomasbeer</h1>
+      <div class="contact-icons">
+        <a href="mailto:kayennepeppaa@gmail.com"><img src="email.png" alt="Email" /></a>
+        <a href="https://github.com/MrHim0thy" target="_blank"><img src="github.png" alt="GitHub" /></a>
+        <a href="https://www.instagram.com/kianthomasbeer/" target="_blank"><img src="Instagram.png" alt="Instagram" /></a>
+      </div>
     </header>
     <main>
       <details id="about" open>
@@ -47,14 +51,6 @@
       <details id="recipes">
         <summary>🍲 Recipes</summary>
         <p>Check out <a href="https://www.instagram.com/worldplatechronicles/" target="_blank">Instagram</a> for weekly dishes.</p>
-      </details>
-      <details id="contact">
-        <summary>📬 Contact</summary>
-        <p>
-          📧 <a href="mailto:kayennepeppaa@gmail.com">kayennepeppaa@gmail.com</a><br />
-          💻 <a href="https://github.com/MrHim0thy" target="_blank">GitHub Profile</a><br />
-          📸 <a href="https://www.instagram.com/kianthomasbeer/" target="_blank">Instagram</a>
-        </p>
       </details>
     </main>
     <footer>

--- a/style.css
+++ b/style.css
@@ -84,13 +84,23 @@ header {
       background: linear-gradient(45deg, #00adb5, #007bff);
       color: white;
       padding: 2.5rem 1rem;
-      text-align: center;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
     }
 header h1 {
       margin: 0;
       font-size: 3rem;
       letter-spacing: 0.5px;
+    }
+.contact-icons {
+      display: flex;
+      gap: 0.8rem;
+    }
+.contact-icons img {
+      width: 32px;
+      height: 32px;
     }
 main {
       max-width: 900px;
@@ -174,6 +184,10 @@ main {
     }
     header h1 {
       font-size: 2rem;
+    }
+    .contact-icons img {
+      width: 24px;
+      height: 24px;
     }
     main {
       padding: 0 0.8rem;


### PR DESCRIPTION
## Summary
- remove the contact nav link and details section
- show email/github/instagram icons in the header
- style header layout and icon sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847beeb6a3883328bf232e937591af3